### PR TITLE
bugfix : Replace dash with underscore in inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Possible values: adoc, jpg, pdf, png, svg, vsdx, xml
 
 Exported folder name. Default `"export"`.
 
-### `remove-page-suffix`
+### `remove_page_suffix`
 
 Remove page suffix when possible (in case of single page file)
 
@@ -47,7 +47,7 @@ Fits the generated image/pdf into the specified height, preserves aspect ratio
 
 crops PDF to diagram size
 
-### `embed-diagram`
+### `embed_diagram`
 
 Includes a copy of the diagram for PNG or PDF
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: "Exported folder name"
     required: false
     default: "export"
-  remove-page-suffix:
+  remove_page_suffix:
     description: "Remove page suffix when possible (in case of single page file)"
     required: false
   border:
@@ -33,7 +33,7 @@ inputs:
   crop:
     description: "crops PDF to diagram size"
     required: false
-  embed-diagram:
+  embed_diagram:
     description: "Includes a copy of the diagram for PNG or PDF"
     required: false
   transparent:

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -7,11 +7,11 @@ args_array+=(
   "--quality" "${INPUT_QUALITY}"
 )
 
-if [ "${INPUT_EMBED-DIAGRAM}" == "true" ]; then
+if [ "${INPUT_EMBED_DIAGRAM}" == "true" ]; then
   args_array+=("--embed-diagram")
 fi
 
-if [ "${INPUT_REMOVE-PAGE-SUFFIX}" == "true" ]; then
+if [ "${INPUT_REMOVE_PAGE_SUFFIX}" == "true" ]; then
   args_array+=("--remove-page-suffix")
 fi
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -9,11 +9,11 @@
 }
 
 @test "with pdf format" {
-  docker_test 0 "pdf" -e INPUT_PATH=nominal -e INPUT_FORMAT=pdf -e INPUT_CROP=true -e INPUT_EMBED-DIAGRAM=true
+  docker_test 0 "pdf" -e INPUT_PATH=nominal -e INPUT_FORMAT=pdf -e INPUT_CROP=true -e INPUT_EMBED_DIAGRAM=true
 }
 
 @test "with png format" {
-  docker_test 0 "png" -e INPUT_PATH=nominal -e INPUT_FORMAT=png -e INPUT_TRANSPARENT=true -e INPUT_EMBED-DIAGRAM=true
+  docker_test 0 "png" -e INPUT_PATH=nominal -e INPUT_FORMAT=png -e INPUT_TRANSPARENT=true -e INPUT_EMBED_DIAGRAM=true
 }
 
 @test "with svg format" {
@@ -29,7 +29,7 @@
 }
 
 @test "with general options" {
-  docker_test 0 "pdf" -e INPUT_PATH=nominal -e INPUT_OUTPUT=test-output -e INPUT_REMOVE-PAGE-SUFFIX=true -e INPUT_BORDER=1 -e INPUT_SCALE=1 -e INPUT_HEIGHT=100 -e INPUT_WIDTH=100
+  docker_test 0 "pdf" -e INPUT_PATH=nominal -e INPUT_OUTPUT=test-output -e INPUT_REMOVE_PAGE_SUFFIX=true -e INPUT_BORDER=1 -e INPUT_SCALE=1 -e INPUT_HEIGHT=100 -e INPUT_WIDTH=100
 }
 
 docker_test() {


### PR DESCRIPTION
Bash does not play well with dash (-) in variable names : https://unix.stackexchange.com/questions/23659/can-shell-variable-name-include-a-hyphen-or-dash

There are some workarounds (see https://github.community/t/dashes-in-docker-action-inputs-produce-unreadable-env-vars/117382) but I think that it is easier to use underscore instead of dash in Github action inputs.

I think that this action has never worked with either `remove-page-suffix`or `embed-diagram` (at least it did not work for me) so I guess that there is no need in maintaining compatibility.