### PR TITLE
Add dependabot file to address issue #4 (Watch Drawio-export release and propose a PR with the updated version)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adding this dependabot file should be enough to address the issue #4.

You should then be able to check if dependabot by visiting "Insights" -> "Dependency Graph" -> "Dependabot"