### PR TITLE
feat: support multiple modes of export 

### DIFF
--- a/.github/workflows/drawio-export-action.yml
+++ b/.github/workflows/drawio-export-action.yml
@@ -1,7 +1,7 @@
 name: drawio-export-action
-on: push
+on: [push, pull_request]
 jobs:
-  drawio-export-action-os-testing:
+  os-testing-with-shallow-clone:
     runs-on: ${{ matrix.os  }}
     strategy:
       fail-fast: false
@@ -11,16 +11,42 @@ jobs:
           # Dockerfile actions are only supported on Linux
           # - macos-latest
           # - windows-latest
+    concurrency:
+      group: drawio-export-action-os-testing-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v2
-      - name: Testing without options
+
+      - name: Verify // it's a force-push commit on a push event?
+        run: echo "::notice ::This is a force-push commit, some tests are desactivated because of it."
+        shell: bash
+        if: ${{ github.event_name == 'push' && github.event.forced }}
+
+      # Test 1
+      - id: must-fail-on-shallow-clone
+        name: Testing fail on shallow clone
         uses: ./
+        with:
+          action-mode: recent
+        continue-on-error: true
+        # Useless on force-push commit on push event
+        if: ${{ !(github.event_name == 'push' && github.event.forced) }}
+      - name: Validate // Testing fail on shallow clone
+        run: |
+          [[ "${{ steps.must-fail-on-shallow-clone.outputs.error_message }}" == "This is a shallow git repository." ]]
+          [[ "${{ steps.must-fail-on-shallow-clone.outcome }}" == "failure" ]]
+          [[ "${{ steps.must-fail-on-shallow-clone.conclusion }}" == "success" ]]
+        shell: bash
+        # Useless on force-push commit on push event
+        if: ${{ !(github.event_name == 'push' && github.event.forced) }}
+
+      # Test 2
       - name: Testing with options
         uses: ./
         with:
           path: tests/data
           format: adoc
-          output: "test-output"
+          output: "test2-output"
           remove-page-suffix: true
           border: 1
           scale: 1
@@ -31,11 +57,77 @@ jobs:
           transparent: true
           quality: 95
           uncompressed: true
+          action-mode: all
+      - name: Validate // Testing with options
+        run: |
+          [[ -s "tests/data/test2-output/nominal-Page-1.adoc" ]]
+          [[ -s "tests/data/test2-output/nominal-Page-1.png" ]]
+          [[ -s "tests/data/test2-output/nominal-Page-2.adoc" ]]
+          [[ -s "tests/data/test2-output/nominal-Page-2.png" ]]
+        shell: bash
 
-  drawio-export-action-release:
+  os-testing-with-full-clone:
+    runs-on: ${{ matrix.os  }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          # Dockerfile actions are only supported on Linux
+          # - macos-latest
+          # - windows-latest
+    concurrency:
+      group: drawio-export-action-os-testing-with-full-clone-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Test 1
+      - name: Testing without any options
+        uses: ./
+
+      # Test 2
+      - name: Testing with recent setup
+        uses: ./
+        with:
+          action-mode: recent
+
+      # Test 3
+      - name: Testing with reference setup
+        uses: ./
+        with:
+          action-mode: reference
+          since-reference: HEAD~2
+
+      # Test 4
+      - name: Testing with only the since-reference option
+        uses: ./
+        with:
+          since-reference: HEAD~2
+
+      # Test 5
+      - id: must-fail-without-since-reference
+        name: Testing fail on missing since-reference option
+        uses: ./
+        with:
+          action-mode: reference
+        continue-on-error: true
+      - name: Validate // Testing fail on missing since-reference option
+        run: |
+          [[ "${{ steps.must-fail-without-since-reference.outputs.error_message }}" == "The 'since-reference' option is mandatory." ]]
+          [[ "${{ steps.must-fail-without-since-reference.outcome }}" == "failure" ]]
+          [[ "${{ steps.must-fail-without-since-reference.conclusion }}" == "success" ]]
+        shell: bash
+
+  release:
     runs-on: ubuntu-latest
     needs:
-      - drawio-export-action-os-testing
+      - os-testing-with-shallow-clone
+      - os-testing-with-full-clone
+    concurrency:
+      group: drawio-export-action-release-${{ github.ref }}
     steps:
       - uses: actions/checkout@v2
       - name: Release this GitHub Action

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,17 +1,17 @@
 name: Lint
-
 on:
   push:
     branches:
       - v1.x
   pull_request:
-
+concurrency:
+  group: linter-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/auto-cancel-redundant-workflow@v1
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM rlespinasse/drawio-export:4.2.0
+RUN apt-get update && apt-get install --no-install-recommends -y git=1:2.20.1-2+deb10u3 && rm -rf /var/lib/apt/lists/*
 COPY drawio-export.sh /opt/drawio-export-action/drawio-export.sh
 ENV DRAWIO_DESKTOP_RUNNER_COMMAND_LINE "/opt/drawio-export-action/drawio-export.sh"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 [![Build Status][1]][2]
 ![Linter Status][3]
-[![Public workflows that use this action.][4]][5]
-[![Licence][6]][7]
+[![Licence][4]][5]
 
-This GitHub Action will export Drawio Files based on [drawio-export][8] docker image.
+This GitHub Action will export Drawio Files based on [drawio-export][6] docker image.
 
 ## Inputs
 
@@ -63,6 +62,34 @@ Output image quality for JPEG. Default `"90"`.
 
 Uncompressed XML output
 
+### `action-mode`
+
+Export mode for this action. Default: auto
+
+Possible values:
+
+- **recent** export only the changed files since a calculated reference
+  - previously pushed commit on `push` event
+  - base commit on `pull request` event
+- **all** export all drawio files without any filter
+- **reference** export since the reference from `since-reference` option
+- **auto** will choose the more appropriated mode
+  - **reference** if `since-reference` option is set,
+  - **recent** if the reference can be calculated,
+  - **all** otherwise
+
+CAUTION: When using a mode other than `all`, you need to checkout all the history.
+
+  ```yaml
+  - uses: actions/checkout@v2
+    with:
+      fetch-depth: 0
+  ```
+
+### `since-reference`
+
+Git Reference serving as base for export. Only when action-mode is set to 'reference'.
+
 ## Example usage
 
 > Export draw.io files inside folders tree of `folder/of/drawio/files` to png files using transparent background
@@ -117,8 +144,6 @@ jobs:
 [1]: https://github.com/rlespinasse/drawio-export-action/workflows/Build/badge.svg
 [2]: https://github.com/rlespinasse/drawio-export-action/actions
 [3]: https://github.com/rlespinasse/drawio-export-action/workflows/Lint/badge.svg
-[4]: https://img.shields.io/endpoint?url=https%3A%2F%2Fapi-git-master.endbug.vercel.app%2Fapi%2Fgithub-actions%2Fused-by%3Faction%3Drlespinasse%2Fdrawio-export-action%26badge%3Dtrue
-[5]: https://github.com/search?o=desc&q=rlespinasse/drawio-export-action+path%3A.github%2Fworkflows+language%3AYAML&s=&type=Code
-[6]: https://img.shields.io/github/license/rlespinasse/drawio-export-action
-[7]: https://github.com/rlespinasse/drawio-export-action/blob/v1.x/LICENSE
-[8]: https://github.com/rlespinasse/drawio-export
+[4]: https://img.shields.io/github/license/rlespinasse/drawio-export-action
+[5]: https://github.com/rlespinasse/drawio-export-action/blob/v1.x/LICENSE
+[6]: https://github.com/rlespinasse/drawio-export

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: "."
   format:
-    description: "Exported format [possible values: adoc, jpg, pdf, png, svg, vsdx, xml]"
+    description: "Exported format [default: pdf] [possible values: adoc, jpg, pdf, png, svg, vsdx, xml]"
     required: false
     default: "pdf"
   output:
@@ -46,6 +46,21 @@ inputs:
   uncompressed:
     description: "Uncompressed XML output"
     required: false
+  action-mode:
+    description: "Export mode for this action [default: auto] [possible values: auto, recent, all, reference]"
+    required: true
+    default: "auto"
+  since-reference:
+    description: "Git Reference serving as base for export (only when action-mode is reference)"
+    required: false
+  internal_push_before:
+    description: "[internal] to get 'before' value on 'push' event"
+    required: true
+    default: ${{ github.event.before }}
+  internal_push_forced:
+    description: "[internal] to get 'forced' value on 'push' event"
+    required: true
+    default: ${{ github.event.forced }}
 branding:
   icon: "layers"
   color: "purple"
@@ -58,3 +73,5 @@ runs:
     # Using 'env' to pass the modified environment variables to the Dockerfile
     INPUT_EMBED_DIAGRAM: ${{ inputs.embed-diagram }}
     INPUT_REMOVE_PAGE_SUFFIX: ${{ inputs.remove-page-suffix }}
+    INPUT_ACTION_MODE: ${{ inputs.action-mode }}
+    INPUT_SINCE_REFERENCE: ${{ inputs.since-reference }}

--- a/drawio-export.sh
+++ b/drawio-export.sh
@@ -39,6 +39,87 @@ if [ -n "${INPUT_WIDTH}" ]; then
   args_array+=("--width" "${INPUT_WIDTH}")
 fi
 
+# Try to calculate the correct action_mode to apply
+action_mode="none"
+error_message=""
+if [ "${INPUT_ACTION_MODE}" == "all" ]; then
+  action_mode="all"
+elif [ "${INPUT_ACTION_MODE}" == "auto" ]; then
+  if [ -n "${INPUT_SINCE_REFERENCE}" ]; then
+    action_mode="reference"
+  elif [ -n "${GITHUB_HEAD_REF}" ]; then
+    action_mode="pull_request"
+  elif [ "${GITHUB_EVENT_NAME}" == "push" ] && [ -n "${INPUT_INTERNAL_PUSH_BEFORE}" ] && [ -z "$(git branch --contains "${INPUT_INTERNAL_PUSH_BEFORE}" 2>&1)" ]; then
+    action_mode="push"
+  else
+    action_mode="all"
+  fi
+elif [ "${INPUT_ACTION_MODE}" == "reference" ]; then
+  if [ -n "${INPUT_SINCE_REFERENCE}" ]; then
+    action_mode="reference"
+  else
+    error_message="The 'since-reference' option is mandatory."
+  fi
+elif [ "${INPUT_ACTION_MODE}" == "recent" ]; then
+  if [ -n "${GITHUB_HEAD_REF}" ]; then
+    action_mode="pull_request"
+  elif [ "${GITHUB_EVENT_NAME}" == "push" ]; then
+    if [ -n "${INPUT_INTERNAL_PUSH_BEFORE}" ]; then
+      if [ -z "$(git branch --contains "${INPUT_INTERNAL_PUSH_BEFORE}" 2>&1)" ]; then
+        action_mode="push"
+      elif [ "${INPUT_INTERNAL_PUSH_FORCED}" == "true" ]; then
+        echo "::notice ::The commit have been force push, can't work with it. Stopping the export."
+        exit 0
+      else
+        error_message="The latest pushed commit ${INPUT_INTERNAL_PUSH_BEFORE} need to be an existing git reference."
+      fi
+    else
+      error_message="Can't get the previous reference to rely on."
+    fi
+  else
+    error_message="Can't find any reference to rely on for the event '${GITHUB_EVENT_NAME}'."
+  fi
+else
+  error_message="Unknown action-mode."
+fi
+
+# Try to calculate the correct reference to used
+if [ "${action_mode}" == "none" ]; then
+  echo "::set-output name=error_message::${error_message}"
+  printf "::error ::%s\n\n%s" \
+    "${error_message}" \
+    "The choosen action mode '${INPUT_ACTION_MODE}' can't be used. Consider switching to 'auto' (default value)."
+  exit 1
+elif [ "${action_mode}" != "all" ]; then
+  # Need a classic clone of the repository to work with
+  # but 'actions/checkout' make a shallow clone by default
+  if [ "$(git rev-parse --is-shallow-repository)" == "true" ]; then
+    error_message="This is a shallow git repository."
+    echo "::set-output name=error_message::${error_message}"
+    printf "::error ::%s\n\nAdd 'fetch-depth: 0' to 'actions/checkout' step to use the '%s' mode." \
+      "${error_message}" \
+      "${INPUT_ACTION_MODE}"
+    exit 1
+  fi
+
+  if [ "$action_mode" == "reference" ]; then
+    reference="${INPUT_SINCE_REFERENCE}"
+  elif [ "$action_mode" == "pull_request" ]; then
+    # shellcheck disable=SC2046
+    reference="$(git merge-base $(git rev-list --parents -n 1 HEAD | cut -d' ' -f2-))"
+  elif [ "$action_mode" == "push" ]; then
+    reference="${INPUT_INTERNAL_PUSH_BEFORE}"
+  fi
+fi
+
+# If a reference is set, we can active the on-changes option for git repository
+if [ -n "${reference}" ]; then
+  args_array+=(
+    "--on-changes"
+    "--git-ref" "${reference}"
+  )
+fi
+
 args_array+=("${INPUT_PATH}")
 
 echo Options: "${args_array[@]}"


### PR DESCRIPTION
Add possibility to also export only changed files or since a specific git reference instead of the current full export

BREAKING CHANGE: by default, only the changed drawio files will  be exported