### PR TITLE
ci(linter): skip checkov unnecessary checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_DOCKER_2
 #checkov:skip=CKV_DOCKER_3
 FROM rlespinasse/drawio-export:v4.26.0
 RUN apt-get update && apt-get install --no-install-recommends -y git=1:2.30.2-1+deb11u2 && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+#checkov:skip=CKV_DOCKER_3
 FROM rlespinasse/drawio-export:v4.26.0
 RUN apt-get update && apt-get install --no-install-recommends -y git=1:2.30.2-1+deb11u2 && rm -rf /var/lib/apt/lists/*
 COPY src/* /opt/drawio-export-action/


### PR DESCRIPTION
- CKV_DOCKER_2: In this use case, the docker image doesn't need any HEALTHCHECK instruction since it's used as CLI command,
- CKV_DOCKER_3: In this use case, I don't want to specify any user, the Dockerfile is targeted for use in a GitHub Action environment.