### PR TITLE
build: use codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rlespinasse

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,23 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: 'docker'
+    directory: '/'
     commit-message:
-      prefix: "feat: "
+      prefix: 'feat: '
     schedule:
-      interval: "daily"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
+      interval: 'daily'
+    labels: []
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     groups:
       dependencies:
         patterns:
-          - "*"
-    reviewers:
-      - "rlespinasse"
-    labels: [ ]
+          - '*'
+    labels: []

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,4 +25,5 @@ jobs:
         uses: super-linter/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_YAML_PRETTIER: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/