### PR TITLE
fix(ci): match dependabot PR author instead of github.actor

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
The auto-merge job filters on `github.actor`. That is `dependabot[bot]` when the PR is opened, but it becomes the login of whoever re-runs the workflow manually — the job is then silently skipped.

Switch to `github.event.pull_request.user.login`, which describes the PR author and does not change on re-run. This is also the form used in the [GitHub documentation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions).

No behaviour change on the nominal trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
